### PR TITLE
Restore Tauri drag permission for custom titlebar

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",
+    "core:window:allow-start-dragging",
     "dialog:allow-open",
     "store:allow-load",
     "store:allow-get",


### PR DESCRIPTION
## Why
PR #24 tightened the Tauri capability set, but it also removed `core:window:allow-start-dragging`.

The app uses `data-tauri-drag-region` on the undecorated custom title bar in `src/App.tsx`, and that drag region depends on the `start_dragging` window permission. Without it, the main window can no longer be dragged.

While validating this fix, the frontend check also exposed stale TypeScript/ESLint compatibility settings that prevented `npm run check` from running cleanly in a fresh worktree. This PR carries the minimal tooling updates needed for that check to pass.

## What Changed
- restore `core:window:allow-start-dragging` in `src-tauri/capabilities/default.json`
- keep the narrower capability set from #24 intact
- remove the invalid `ignoreDeprecations` setting from `tsconfig.json`
- normalize frontend tool versions in `package.json` / `package-lock.json` so install and check succeed with the current toolchain

## Testing
- `cargo check`
- `npm run check`