### PR TITLE
fix(csp): add IPC origins to production CSP to fix white screen

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "eso-addon-manager"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,8 +21,15 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' https://cdn-eso.mmoui.com https://*.esoui.com; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'",
-      "devCsp": "default-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' https://cdn-eso.mmoui.com https://*.esoui.com; connect-src 'self' ws://localhost:* http://localhost:* http://127.0.0.1:*"
+      "csp": {
+        "default-src": "'self'",
+        "script-src": "'self'",
+        "style-src": "'self' 'unsafe-inline'",
+        "img-src": "'self' https://cdn-eso.mmoui.com https://*.esoui.com",
+        "font-src": "'self'",
+        "connect-src": "ipc: http://ipc.localhost"
+      },
+      "devCsp": "default-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src 'self' https://cdn-eso.mmoui.com https://*.esoui.com; font-src 'self'; connect-src ipc: http://ipc.localhost 'self' ws://localhost:* http://localhost:* http://127.0.0.1:*"
     }
   },
   "plugins": {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,32 @@ import { Toaster } from "@/components/ui/sonner";
 import "./index.css";
 import "./App.css";
 
+// Catch fatal errors that occur before React mounts (CSP violations, script
+// load failures, etc.) and display them instead of a blank white screen.
+function showFatalError(msg: string) {
+  const root = document.getElementById("root");
+  if (!root) return;
+  root.innerHTML = `<div style="padding:32px;color:#ef4444;font-family:monospace;white-space:pre-wrap">
+    <h1 style="color:#fff;margin-bottom:16px">Fatal Error</h1>
+    <p>${msg}</p>
+    <p style="margin-top:16px;opacity:0.5">Try restarting the application.</p>
+  </div>`;
+}
+
+window.addEventListener("error", (e) => {
+  console.error("Global error:", e.error ?? e.message);
+  if (!document.getElementById("root")?.children.length) {
+    showFatalError(e.message);
+  }
+});
+
+window.addEventListener("unhandledrejection", (e) => {
+  console.error("Unhandled rejection:", e.reason);
+  if (!document.getElementById("root")?.children.length) {
+    showFatalError(String(e.reason));
+  }
+});
+
 class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
   state: { error: Error | null } = { error: null };
 


### PR DESCRIPTION
## What
Fixes the production CSP that was blocking all Tauri IPC calls, causing a white screen after updating to v0.3.0. Also adds a global error safety net so future errors display a message instead of a blank page.

## Why
The production CSP had `connect-src 'self'` which only matches the app origin (`https://tauri.localhost`). Tauri v2 on Windows uses `http://ipc.localhost` for all `invoke()` calls — a different origin that was being silently blocked. Every command call failed, the React app got no data, and rendered nothing.

Dev mode was unaffected because `devCsp` used a permissive `connect-src` that happened to allow everything.

## How
- Rewrote the CSP from a string to the **object format** recommended by [Tauri v2 docs](https://v2.tauri.app/security/csp/), with `connect-src: "ipc: http://ipc.localhost"`
- Added explicit `font-src: "'self'"` directive (was falling back to restrictive `default-src`)
- Updated `devCsp` to include `ipc: http://ipc.localhost` for consistency
- Added global `error` and `unhandledrejection` listeners in `main.tsx` that display a diagnostic message if React hasn't mounted yet — prevents future blank white screens
- Synced `Cargo.lock` version from 0.2.2 → 0.3.0 (missed in the release bump)

## Testing
- `npm run check` passes (TypeScript, ESLint, Prettier)
- `cargo clippy` and `cargo fmt` pass
- Production build should now correctly allow IPC calls through the CSP